### PR TITLE
Update Node.js to v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: npm
       - run: npm ci
       - run: npm run test

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ outputs:
   output-text:
     description: 'The converted text'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'activity'


### PR DESCRIPTION
Node.js v16 has been deprecated.
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
